### PR TITLE
Fixes for wishbone build

### DIFF
--- a/adv_dbg_if.core
+++ b/adv_dbg_if.core
@@ -1,0 +1,31 @@
+CAPI=1
+[main]
+description = "Advanced Debug System Interface provides jtag debugging to cores"
+
+[fileset adv_dbg_if]
+files =
+ verilog/wb/adbg_top_wb.sv
+ verilog/wb/adbg_wb_pkg.sv
+ verilog/wb/adbg_wb_biu.sv
+ verilog/wb/adbg_wb_module.sv
+ verilog/wb/adbg_jsp_wb_biu.sv
+ verilog/wb/adbg_jsp_wb_module.sv
+ verilog/ahb3/adbg_top_ahb3.sv
+ verilog/ahb3/adbg_ahb3_pkg.sv
+ verilog/ahb3/adbg_ahb3_biu.sv
+ verilog/ahb3/adbg_ahb3_module.sv
+ verilog/ahb3/adbg_jsp_apb_biu.sv
+ verilog/ahb3/adbg_jsp_apb_module.sv
+ verilog/core/adbg_pkg.sv
+ verilog/core/adbg_bus_module_core.sv
+ verilog/core/adbg_jsp_pkg.sv
+ verilog/core/adbg_jsp_module_core.sv
+ verilog/core/adbg_or1k_pkg.sv
+ verilog/core/adbg_or1k_biu.sv
+ verilog/core/adbg_or1k_module.sv
+ verilog/core/adbg_or1k_status_reg.sv
+ verilog/core/adbg_crc32.v
+ verilog/core/syncflop.v
+ verilog/core/bytefifo.v
+ verilog/core/syncreg.v
+file_type = systemVerilogSource

--- a/verilog/wb/adbg_top_wb.sv
+++ b/verilog/wb/adbg_top_wb.sv
@@ -47,12 +47,12 @@ module adbg_top_wb #(
 )
 (
   // JTAG signals
-  input                     trstn_i,
   input                     tck_i,
   input                     tdi_i,
   output reg                tdo_o,
 
   // TAP states
+  input                     tlr_i,       //TestLogicReset
   input                     shift_dr_i,
   input                     pause_dr_i,
   input                     update_dr_i,
@@ -141,8 +141,8 @@ module adbg_top_wb #(
 
   //////////////////////////////////////////////////////////
   // Module select register and select signals
-  always @(posedge tck_i, negedge trstn_i)
-  if      (!trstn_i)
+  always @(posedge tck_i, posedge tlr_i)
+  if (tlr_i)
     module_id_reg <= 'h0;
   else if (debug_select_i && select_cmd && update_dr_i && !select_inhibit)       // Chain select
     module_id_reg <= module_id_in;
@@ -157,8 +157,8 @@ module adbg_top_wb #(
 
 ///////////////////////////////////////////////
 // Data input shift register
-  always @ (posedge tck_i,negedge trstn_i)
-    if      (!trstn_i                     ) input_shift_reg <= 'h0;
+  always @ (posedge tck_i, posedge tlr_i)
+    if      ( tlr_i                       ) input_shift_reg <= 'h0;
     else if ( debug_select_i && shift_dr_i) input_shift_reg <= {tdi_i, input_shift_reg[DBG_TOP_DATAREG_LEN-1:1]};
 
   /*
@@ -169,7 +169,7 @@ module adbg_top_wb #(
     .DATA_WIDTH  ( DATA_WIDTH  )
   ) i_dbg_wb (
     // JTAG signals
-    .trstn_i          ( trstn_i      ),
+    .tlr_i            ( tlr_i        ),
     .tck_i            ( tck_i        ),
     .module_tdo_o     ( tdo_busif    ),
     .tdi_i            ( tdi_i        ),
@@ -232,7 +232,7 @@ module adbg_top_wb #(
 
 
 adbg_jsp_wb_module i_dbg_jsp (
-  .rst_i            (~trstn_i),
+  .rst_i            ( tlr_i),
 
   // JTAG signals
   .tck_i            ( tck_i),

--- a/verilog/wb/adbg_top_wb.sv
+++ b/verilog/wb/adbg_top_wb.sv
@@ -64,7 +64,6 @@ module adbg_top_wb #(
 
   // WISHBONE Master Interface Signals
   input                     wb_clk_i,
-  input                     wb_rst_i,
 
   output                    wb_cyc_o,
   output                    wb_stb_o,
@@ -80,7 +79,7 @@ module adbg_top_wb #(
 
   // WISHBONE Target Interface Signals (JTAG Serial Port)
   input                     wb_jsp_clk_i,
-                            wb_jsp_rst_i,
+  input                     wb_jsp_rst_i,
   input                     wb_jsp_cyc_i,
   input                     wb_jsp_stb_i,
   input                     wb_jsp_we_i,
@@ -206,7 +205,6 @@ module adbg_top_wb #(
   )
   i_dbg_cpu_or1k (
     // JTAG signals
-   .trstn_i         ( trstn_i      ),
    .tck_i           ( tck_i        ),
    .module_tdo_o    ( tdo_cpu      ),
    .tdi_i           ( tdi_i        ),

--- a/verilog/wb/adbg_wb_biu.sv
+++ b/verilog/wb/adbg_wb_biu.sv
@@ -70,7 +70,7 @@ module adbg_wb_biu #(
   // Wishbone signals
   input                         wb_clk_i,
   output reg                    wb_cyc_o,
-         reg                    wb_stb_o,
+  output reg                    wb_stb_o,
                                 wb_we_o,
   output     [             2:0] wb_cti_o,
   output     [             1:0] wb_bte_o,

--- a/verilog/wb/adbg_wb_module.sv
+++ b/verilog/wb/adbg_wb_module.sv
@@ -50,12 +50,12 @@ module adbg_wb_module #(
 )
 (
   // JTAG signals
-  input                     trstn_i,
   input                     tck_i,
   output                    module_tdo_o,
   input                     tdi_i,
 
   // TAP states
+  input                     tlr_i,
   input                     capture_dr_i,
   input                     shift_dr_i,
   input                     update_dr_i,
@@ -128,7 +128,7 @@ module adbg_wb_module #(
   )
   bus_module_core_inst (
     //Debug Module ports
-    .dbg_rst ( ~trstn_i ),
+    .dbg_rst ( tlr_i ),
     .dbg_clk ( tck_i ),
     .dbg_tdi ( tdi_i ),
     .dbg_tdo ( module_tdo_o ),


### PR DESCRIPTION
I found this fork of advanced debug sys has fixed a few bugs compared to what we use in OpenRISC / fusesoc ecosystem.  These fixes get this building for me.

The core file patch is optional, but it would be helpful to have here.

Some requests:
 - The current version of adv debug sys we have  is 3.1.0, could you tag the git repo is `v4.0` or something similar?
 - Do you have any test bench that you use for this core?

Mentioning @olofk as he may be interested.